### PR TITLE
single player score tracking

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -16,11 +16,11 @@ class cBoard(object):
     #TODO add wild card center to template
     template=[["R","X","X","X","H","X","X","X","R"],
              ["X",".",".",".","X",".",".",".","X"],
-             ["X",".","P",".","X",".","P",".","X"],
+             ["X","L","P",".","X","M","P",".","X"],
              ["X",".",".",".","X",".",".",".","X"],
              ["H","X","X","X","C","X","X","X","H"],
              ["X",".",".",".","X",".",".",".","X"],
-             ["X",".","P",".","X",".","P",".","X"],
+             ["X","N","P",".","X","O","P",".","X"],
              ["X",".",".",".","X",".",".",".","X"],
              ["R","X","X","X","H","X","X","X","R"],]
     #TODO add thje ability to save a string here that captures the colors of the board
@@ -49,19 +49,37 @@ class cBoard(object):
                         self.board[i][j] = tile(triviaType.RED, tileDistinction.ROLL, 10, i, j)
                     case "C":
                         self.board[i][j] = tile(triviaType.RED, tileDistinction.CENTER, 10, i, j)
+                    case "L":
+                        self.board[i][j] = tile(triviaType.RED, tileDistinction.PLAYER1, 10, i, j)
+                    case "M":
+                        self.board[i][j] = tile(triviaType.RED, tileDistinction.PLAYER2, 10, i, j)
+                    case "N":
+                        self.board[i][j] = tile(triviaType.RED, tileDistinction.PLAYER3, 10, i, j)
+                    case "O":
+                        self.board[i][j] = tile(triviaType.RED, tileDistinction.PLAYER4, 10, i, j)                                                                        
 
     def drawBoard(self, screen, currentNeighbors):
+        optionTileBlackOutline = True        
         for col in range(9):
             for row in range(9):
-                if self.board[col][row].mDistinct == tileDistinction.SPECIAL:
-                    pygame.draw.rect(screen, self.board[col][row].mColor, self.board[col][row].box, 4)
+                if self.board[col][row].mDistinct != tileDistinction.NULL:
+                    self.board[col][row].drawTile(screen)
+                    if (col, row) in currentNeighbors:
+                        pygame.draw.rect(screen, base3, self.board[col][row].box, 5)
                 else:
-                    if self.board[col][row].mDistinct != tileDistinction.NULL:
-                        self.board[col][row].drawTile(screen)
-                        if (col, row) in currentNeighbors:
-                            pygame.draw.rect(screen, base3, self.board[col][row].box, 3)
-                    else:
-                        pygame.draw.rect(screen, self.board[col][row].mColor, self.board[col][row].box)
+                    pygame.draw.rect(screen, self.board[col][row].mColor, self.board[col][row].box)
+
+                # Add optional thin black border around tiles
+                if(optionTileBlackOutline):
+                    if self.board[col][row].mDistinct not in (tileDistinction.NULL,tileDistinction.PLAYER1,
+                                                            tileDistinction.PLAYER2,tileDistinction.PLAYER3,
+                                                            tileDistinction.PLAYER4,tileDistinction.SPECIAL):
+                        pygame.draw.rect(screen, black, self.board[col][row].box, 1)
+                
+                # Add gray border around score tile for visible player(s)
+                if self.board[col][row].mDistinct == tileDistinction.SPECIAL and \
+                    self.board[col][row].title_color==white:
+                    pygame.draw.rect(screen, base00, self.board[col][row].box, 4)
 
     def correctBoard(self):
         for i in range(9):

--- a/src/colors.py
+++ b/src/colors.py
@@ -20,6 +20,9 @@ darkBlue = (16, 62, 94)
 cyan = (42, 161, 152)
 green = (133, 193, 0)
 darkGreen = (56, 82, 0)
+white = (255,255,255)
+black = (0,0,0)
+winner_green = (102,255,102)
 
 #HQ colors
 HQ_red = (171, 5, 41)

--- a/src/dice.py
+++ b/src/dice.py
@@ -12,6 +12,7 @@ class dice(object):
     diceValue = 0
     current_number = 0
     update_interval = 1  # update every 1000 milliseconds (1 second)
+    optionalFastDice = True    
     total_duration = 3000  # total duration of the animation (5 seconds)
     timer = 0  # track the time since the last number update
     start_time = pygame.time.get_ticks()  # get the initial time
@@ -34,7 +35,10 @@ class dice(object):
     #with concurrency for this
     def rollDice(self, screen):
         self.update_interval = 1  # update every 1000 milliseconds (1 second)
-        self.total_duration = 3000  # total duration of the animation (5 seconds)
+        if(self.optionalFastDice):
+            self.total_duration = 300
+        else:        
+            self.total_duration = 3000  # total duration of the animation (5 seconds)
         self.timer = 0  # track the time since the last number update
         self.rolling = True
         # Main game loop

--- a/src/menu.py
+++ b/src/menu.py
@@ -83,7 +83,7 @@ class menu(object):
     def addChildComponent(self, inComponent):
         x_offset = self.ScreenCoords[0]
         width = self.menu_width //2
-        height = width // 2
+        height = width // 4
         y_offset = self.ScreenCoords[1] - self.menu_height // 2 + height + 50
         #TODO Might depricate this, this function is doing too much
         if len(self.child_Dictionary[childType.BUTTON]) > 0 and (isinstance(inComponent, menu) or isinstance(inComponent, textWidget)):

--- a/src/player.py
+++ b/src/player.py
@@ -14,7 +14,7 @@ class player(object):
     circle_highlight_color = blue
     currCordinate = (0,0)
     dragging = False  # This flag checks if the circle is being dragged
-    playerScore = 0
+    playerScore =  {"c1":"_","c2":"_","c3":"_","c4":"_"}
     isTurn = True
     hasRolled = False
     clampBox = boundingBox()
@@ -30,6 +30,7 @@ class player(object):
             return possibleNeighbors
         if (inboard.board[curPosition[0]][curPosition[1]].mDistinct == tileDistinction.NORMAL or inboard.board[curPosition[0]][curPosition[1]].mDistinct == tileDistinction.HQ or inboard.board[curPosition[0]][curPosition[1]].mDistinct == tileDistinction.ROLL) and curPosition not in(possibleNeighbors):
             possibleNeighbors.append(curPosition)
+
         self.getNeighbors(inboard, (curPosition[0] - 1, curPosition[1]), diceRolls - 1, possibleNeighbors)
         self.getNeighbors(inboard, (curPosition[0] + 1, curPosition[1]), diceRolls - 1, possibleNeighbors)
         self.getNeighbors(inboard, (curPosition[0], curPosition[1] - 1), diceRolls - 1, possibleNeighbors)
@@ -147,6 +148,6 @@ class player(object):
             self.circle_highlight_color = player_green_highlight
         self.circle_x = inX
         self.circle_y = inY
-        self.playerScore = 0
+        self.playerScore =  {"c1":"_","c2":"_","c3":"_","c4":"_"}
         self.clampBox = boundingBox()
     

--- a/src/tile.py
+++ b/src/tile.py
@@ -18,9 +18,15 @@ class tileDistinction(Enum):
     SPECIAL = 3
     CENTER = 4
     NULL = 5
+    PLAYER1 = 6
+    PLAYER2 = 7
+    PLAYER3 = 8
+    PLAYER4 = 9
+
 class tile(object):
     #standard convention in python to mark private variables with "__"
     
+    optionThreeDimensiaonalTiles = False
     size = 50
     mColor = (base0)
     mComplimentColor = (base0)
@@ -48,11 +54,21 @@ class tile(object):
     #def drawTile(self, screen):
     def drawTile(self, screen):
         #TODO move this to the tile class
-        pygame.draw.rect(screen, debug_red, self.box)
-        pygame.draw.rect(screen, self.mComplimentColor, self.box)
-        pygame.draw.rect(screen, self.mColor, self.inner_box)
-        pygame.draw.rect(screen, self.mComplimentColor, self.box, 3)
-        if self.mDistinct == tileDistinction.HQ:
+        if(self.optionThreeDimensiaonalTiles):
+            if self.mDistinct not in (tileDistinction.PLAYER1,tileDistinction.PLAYER2,
+                                      tileDistinction.PLAYER3,tileDistinction.PLAYER4,
+                                      tileDistinction.SPECIAL):
+                pygame.draw.rect(screen, debug_red, self.box)
+                pygame.draw.rect(screen, self.mComplimentColor, self.box)
+                pygame.draw.rect(screen, self.mColor, self.inner_box)
+                pygame.draw.rect(screen, self.mComplimentColor, self.box, 3)
+            else:
+                pygame.draw.rect(screen, self.mColor, self.box)
+        else:
+            pygame.draw.rect(screen, self.mColor, self.box)
+        if self.mDistinct in (tileDistinction.SPECIAL,tileDistinction.PLAYER1,
+                              tileDistinction.PLAYER2,tileDistinction.PLAYER3,
+                              tileDistinction.PLAYER4,tileDistinction.HQ):
             text_surface = self.title.render(self.title_text, True, self.title_color)
             text_rect = text_surface.get_rect(center=(self.box.centerx, self.box.centery))
             screen.blit(text_surface, text_rect)
@@ -83,6 +99,30 @@ class tile(object):
         match dist:
             case tileDistinction.NULL:
                 self.mColor = null
+            case tileDistinction.PLAYER1:
+                self.title_text = ""
+                self.title_text_size = inSize * 3
+                self.title = pygame.font.Font(None, self.title_text_size)                
+                self.mColor = null
+                self.title_color = white
+            case tileDistinction.PLAYER2:
+                self.title_text = ""
+                self.title_text_size = inSize * 3
+                self.title = pygame.font.Font(None, self.title_text_size)                
+                self.mColor = null
+                self.title_color = white
+            case tileDistinction.PLAYER3:
+                self.title_text = ""
+                self.title_text_size = inSize * 3
+                self.title = pygame.font.Font(None, self.title_text_size)                
+                self.mColor = null
+                self.title_color = white
+            case tileDistinction.PLAYER4:
+                self.title_text = ""
+                self.title_text_size = inSize * 3
+                self.title = pygame.font.Font(None, self.title_text_size)                
+                self.mColor = null
+                self.title_color = white                  
             case tileDistinction.HQ:
                 self.title_text = "HQ"
                 self.title_text_size = inSize * 3
@@ -92,30 +132,30 @@ class tile(object):
                         self.mTrivia = triviaType.RED
                         self.mColor = HQ_red
                         self.mComplimentColor = HQ_dark_red                 
-                        self.title_color = HQ_dark_red
+                        self.title_color = black #HQ_dark_red
                     case triviaType.BLUE:
                         self.mTrivia = triviaType.BLUE
                         self.mColor = HQ_blue
                         self.mComplimentColor = HQ_dark_blue
-                        self.title_color = HQ_dark_blue
+                        self.title_color = black #HQ_dark_blue
                     case triviaType.GREEN:
                         self.mTrivia = triviaType.GREEN
                         self.mColor = HQ_green
                         self.mComplimentColor = HQ_dark_green
-                        self.title_color = HQ_dark_green
+                        self.title_color = black #HQ_dark_green
                     case triviaType.YELLOW:
                         self.mTrivia = triviaType.YELLOW
                         self.mColor = HQ_yellow
                         self.mComplimentColor = HQ_dark_yellow
-                        self.title_color = HQ_dark_yellow
+                        self.title_color = black #HQ_dark_yellow
             case tileDistinction.ROLL:
                 self.mColor = base3
                 self.mComplimentColor=base0
                 self.title_text = "Roll"
-                self.title_color = base0
+                self.title_color = black #base0
                 self.title_text_size = inSize * 2
                 self.etitle_text = "Again"
-                self.etitle_color = base0
+                self.etitle_color = black #base0
                 self.etitle_text_size = inSize * 2
                 self.etitle = pygame.font.Font(None, self.etitle_text_size)
                 self.title = pygame.font.Font(None, self.title_text_size)
@@ -123,15 +163,19 @@ class tile(object):
                 self.mColor = magenta
                 self.mComplimentColor=violet
                 self.title_text = "Trivial"
-                self.title_color = violet
+                self.title_color = black #violet
                 self.title_text_size = inSize * 2
                 self.etitle_text = "Compute"
-                self.etitle_color = violet
+                self.etitle_color = black #violet
                 self.etitle_text_size = inSize * 2
                 self.etitle = pygame.font.Font(None, self.etitle_text_size)
                 self.title = pygame.font.Font(None, self.title_text_size)
             case tileDistinction.SPECIAL:
-                self.mColor = base00
+                self.mColor = null
+                self.title_text = "____"
+                self.title_text_size = inSize * 3
+                self.title = pygame.font.Font(None, self.title_text_size)                
+                self.title_color = null
             case tileDistinction.NORMAL:
                 match inColor:
                     case triviaType.RED:


### PR DESCRIPTION
- Added buttons for advancing player's token around board and giving player credit for correct answers
- Add player name(s) and score(s) into middle tiles
- Made the 3D tile appearance optional (and set it as not 3D for default)
- Made black outlines around each tile optional (and set it as default)
- Made fast dice and option (and set it as default)
- Changed all text on board to black for better contrast (just commented out the previous colors for now)
- Defaulted bounding box to off
- Started bounding box and dice at 0 (have to start game by rolling dice)

--Issues--
- sub menu text size issue - I needed space for more buttons so I reduced the height of the buttons in the menu, but it impacted the text size for the sub menu, needs to be fixed up
- getNeighbors issue - I created a quick "crownVictor" function for the game winning state but I wasn't able to test it because of an issue with "neighbor" squares (doesn't make center square a possible move at end of game). Also noticed some other instances where there are errors in the possible neighbor squares that can be moved to (the ones highlighted with white outline).
- removal of TestButton1 (putting the bounding box button into position 0 in the menu) caused odd behavior with the bounding box being on/off (flickering as token is dragged around screen). I just added TestButton1 back in for now as I didn't have time to troubleshoot the cause further.