### PR TITLE
Fix issue where sql scripts were running in random order in databaseSetup.py

### DIFF
--- a/src/databaseSetup.py
+++ b/src/databaseSetup.py
@@ -51,6 +51,8 @@ def execute_sql_scripts(conn):
         # List all .sql files in the directory
         sql_files = [file for file in os.listdir(SQL_SCRIPTS_DIR) if file.endswith('.sql')]
 
+        sql_files.sort()
+
         # Execute each SQL script
         for file in sql_files:
             script_path = os.path.join(SQL_SCRIPTS_DIR, file)


### PR DESCRIPTION
The scripts running in random order caused errors, because the tables have to be created before we can insert values into them. 

I adding sorting, so the script files will be sorted before they are executed. 
