### PR TITLE
fully working save/restore feature, along with bug fixes for issues that were found during testing

### DIFF
--- a/scripts/01_CREATE_categories_questions_table.sql
+++ b/scripts/01_CREATE_categories_questions_table.sql
@@ -1,3 +1,7 @@
+DROP TABLE IF EXISTS questions;
+
+DROP TABLE IF EXISTS categories;
+
 CREATE TABLE categories (
     "id" SERIAL PRIMARY KEY,
     "name" VARCHAR UNIQUE

--- a/scripts/03_CREATE_saved_game_states_table.sql
+++ b/scripts/03_CREATE_saved_game_states_table.sql
@@ -1,8 +1,10 @@
+DROP TABLE IF EXISTS saved_game_states;
+
 CREATE TABLE saved_game_states (
     "id" SERIAL PRIMARY KEY, -- game id
     "playerPositions" JSONB NOT NULL, -- '{"player1": [1, 2], "player2": [1, 3]}'
 	"playerScores" JSONB NOT NULL, -- '{"player1": {"c1":"_","c2":"_","c3":"_","c4":"_"}, "player2": {"c1":"_","c2":"_","c3":"_","c4":"_"}}'
-	"playerOrder" VARCHAR[] NOT NULL, -- ['player1', 'player2'] 
-	"currentPlayer" VARCHAR NOT NULL,
+	"setupInfo" JSONB NOT NULL,
+	"currentPlayerIndex" INT NOT NULL,
 	"date" TIMESTAMP NOT NULL
 );

--- a/src/databaseConnection.py
+++ b/src/databaseConnection.py
@@ -70,26 +70,28 @@ class databaseConnection(object):
         query = "SELECT id, name FROM categories"
         return self.executeQueryFetchAll(query)
 
-    def getPlayerPositionsOfLastSavedGame(self):
-        query = "SELECT \"playerPositions\" FROM saved_game_states ORDER BY date DESC"
+    def getGameStateOfLastSavedGame(self):
+        query = "SELECT * FROM saved_game_states ORDER BY date DESC"
         return self.executeQueryFetchOne(query)
 
-    def saveCurrentGameState(self, playerList, currPlayer, playerOrder):
-        count = 0
+    def saveCurrentGameState(self, playerList, setupInfo, currPlayerIndex):
 
-        # Initialize dictionary
+        # Initialize dictionaries
         player_position_data = {}
+        player_score_data = {}
 
-        # Populate dictionary with incrementing count
+        count = 0
+        # Populate dictionaries with incrementing player count
         for player in playerList:
             player_position_data[f'player{count}'] = player.currCoordinate
+            player_score_data[f'player{count}'] = player.playerScore
             count += 1
 
         # Convert the dictionary to a JSON string
         json_player_position_data = json.dumps(player_position_data)
-        
-        #TODO format currPlayer and playerOrder and use those values in the insert statement instead of the test values
-        
-        query = "INSERT INTO saved_game_states (\"playerPositions\", \"playerScores\", \"playerOrder\", \"currentPlayer\", \"date\") VALUES (%s , %s, %s, %s, current_timestamp)"
-        params = (json_player_position_data, [], [], 'testCurrPlayer',)
+        json_player_score_data = json.dumps(player_score_data)
+        json_setupInfo = json.dumps(setupInfo)
+
+        query = "INSERT INTO saved_game_states (\"playerPositions\", \"playerScores\", \"setupInfo\", \"currentPlayerIndex\", \"date\") VALUES (%s , %s, %s, %s, current_timestamp)"
+        params = (json_player_position_data, json_player_score_data, json_setupInfo, currPlayerIndex)
         return self.executeQueryInsert(query, params)

--- a/src/main.py
+++ b/src/main.py
@@ -44,9 +44,10 @@ class mainMenu(object):
     screen = pygame.display.set_mode((WIDTH, HEIGHT))
     
 class pygameMain(object):
-    def __init__(self, databaseConnection, setupInfo):
+    def __init__(self, databaseConnection, setupInfo, currPlayerIndex):
         self.databaseConnection = databaseConnection
         self.setupInfo = setupInfo
+        self.clientNumber = currPlayerIndex
 
         # Initialize playerList using setupInfo
         self.playerList = []
@@ -88,7 +89,7 @@ class pygameMain(object):
    
     #TODO, change how player list will work across network
     #currPlayer = playerList[0]
-    clientNumber = 0
+    # clientNumber = 0
     currState = 0
     drawDice = False
     
@@ -218,18 +219,18 @@ class pygameMain(object):
                     self.playerList[count].circle_y += offset
             count += 1
         #TODO change this so that it sets respective player to what the server dictates the client should be
-        self.currPlayer = self.playerList[0]
+        self.currPlayer = self.playerList[self.clientNumber]
         #set player relative to the coords of the board
         #this takes in a tile object from the board
         #self.currPlayer.updateBoardPos(self.playBoard.board[4][4], self.diceRoll)
 
     def initializePlayersForRestoreGame(self, convertedPlayerPositionsTuple):
-        localColorList = [player_red, player_blue, player_green, player_yellow]
+        # localColorList = [player_red, player_blue, player_green, player_yellow]
         count = 0
         offset = 17
 
         for play in self.playerList:
-            play = player(11, self.WIDTH // 2, self.HEIGHT // 2, localColorList[count])
+            # play = player(11, self.WIDTH // 2, self.HEIGHT // 2, localColorList[count])
             
             (playerName, (x, y)) = convertedPlayerPositionsTuple[count]
             play.updateBoardPos(self.playBoard.board[x][y], self.diceRoll)
@@ -250,7 +251,15 @@ class pygameMain(object):
                     self.playerList[count].circle_y += offset
             count += 1
         #TODO change this so that it sets respective player to what the server dictates the client should be
-        self.currPlayer = self.playerList[0]
+        self.currPlayer = self.playerList[self.clientNumber]
+
+    def restorePlayerScores(self, savedPlayerScores):
+        for i in range(len(self.playerList)):
+            self.playerList[i].playerScore = savedPlayerScores[i]
+            self.playBoard.board[self.playerList[i].playerScorePosition[0]][self.playerList[i].playerScorePosition[1]+1].title_text = str(self.playerList[i].playerScore["c1"])+ \
+                str(self.playerList[i].playerScore["c2"])+     \
+                str(self.playerList[i].playerScore["c3"])+     \
+                str(self.playerList[i].playerScore["c4"])
 
     def drawPlayers(self):
         for play in self.playerList:
@@ -383,7 +392,7 @@ class pygameMain(object):
                     print("RESET!")
                     self.trivMenu.resetTimer()
                     self.clientNumber +=1
-                    if self.clientNumber >= 4:
+                    if self.clientNumber >= self.setupInfo['number_of_players']:
                         self.clientNumber = 0
                     self.currPlayer = self.playerList[self.clientNumber]
                     question = ''
@@ -403,7 +412,7 @@ class pygameMain(object):
                     self.currState = 2
                 elif abs == self.testMenuButtons['Save Game']-1:
                     print('Save Game')
-                    self.databaseConnection.saveCurrentGameState(self.playerList, self.currPlayer, [])
+                    self.databaseConnection.saveCurrentGameState(self.playerList, self.setupInfo, self.clientNumber)
                 if abs == 3 or dbs == -3:
                     self.settingsMenu.slideIn((self.WIDTH//2, self.HEIGHT//2))
                     self.testMenu.lockOut = not self.testMenu.lockOut
@@ -433,7 +442,7 @@ class pygameMain(object):
                                 self.crownVictor()
                     else:
                         self.clientNumber +=1
-                        if self.clientNumber >= 4:
+                        if self.clientNumber >= self.setupInfo['number_of_players']:
                             self.clientNumber = 0
                         self.currPlayer = self.playerList[self.clientNumber]
             #game state logic
@@ -551,7 +560,7 @@ def main():
         if setupInfo == {}:
             print("No setup info found.")
             return
-        demo = pygameMain(database, setupInfo)
+        demo = pygameMain(database, setupInfo, 0)
         #demo.createGameSetupMenu(database)
         #demo.mainMenuLoop()
         demo.createSettingsMenu()
@@ -561,23 +570,51 @@ def main():
         #database.close()
     elif selected_menu_action == "restore":
         database = databaseConnection(dbname='trivialCompute', user='postgres', password='postgres')
-        demo = pygameMain(database)
-        #demo.mainMenuLoop()
-        demo.createSettingsMenu()
-        demo.createTriviaMenu()
 
-        playerPostionsOfLastSavedGameFromDB = database.getPlayerPositionsOfLastSavedGame()
+        gameStateFromDB = database.getGameStateOfLastSavedGame()
 
-        if playerPostionsOfLastSavedGameFromDB is None:
+        if gameStateFromDB is None:
             print("No saved game state found.")
+            setupInfo = runSetupMenu(database)
+            if(setupInfo['number_of_players'] in [2, 3, 4]):
+                setupInfo = run_order_menu(setupInfo)
+            if setupInfo == {}:
+                print("No setup info found.")
+                return
+            demo = pygameMain(database, setupInfo, 0)
+            demo.createSettingsMenu()
+            demo.createTriviaMenu()
             demo.initializePlayersForNewGame()
+            demo.mainLoop()
+
         else:
             print("Previous game state found.")
-            playerPositionsDictionary = playerPostionsOfLastSavedGameFromDB[0]
-            convertedPlayerPositionsTuple = tuple((key, tuple(value)) for key, value in playerPositionsDictionary.items())
-            demo.initializePlayersForRestoreGame(convertedPlayerPositionsTuple)
+            (id, playerPositions, playerScores, setupInfo, currPlayerIndex, gameDate) = gameStateFromDB
+            converted_setupInfo = {
+                'number_of_players': setupInfo['number_of_players'],
+                'players': [
+                    {
+                        'name': player['name'],
+                        'color': tuple(player['color'])  # Convert color list to tuple
+                    }
+                    for player in setupInfo['players']
+                ],
+                'categories': setupInfo['categories']
+            }
 
-        demo.mainLoop()
+            demo = pygameMain(database, converted_setupInfo, currPlayerIndex)
+            #demo.mainMenuLoop()
+            demo.createSettingsMenu()
+            demo.createTriviaMenu()
+
+            playerScoresList = list(playerScores.values())
+            demo.restorePlayerScores(playerScoresList)
+
+            convertedPlayerPositionsTuple = tuple((key, tuple(value)) for key, value in playerPositions.items())
+            demo.initializePlayersForRestoreGame(convertedPlayerPositionsTuple)
+            
+            demo.mainLoop()
+
         #database.close()
     else:
         pygame.quit()

--- a/src/main.py
+++ b/src/main.py
@@ -385,6 +385,9 @@ class pygameMain(object):
                     if self.clientNumber >= 4:
                         self.clientNumber = 0
                     self.currPlayer = self.playerList[self.clientNumber]
+                    # question = ''
+                    # answer = ''
+                    # hasPulled = False
                     self.currState = 0
                     
                 #self.slider.listen(event)

--- a/src/main.py
+++ b/src/main.py
@@ -385,9 +385,9 @@ class pygameMain(object):
                     if self.clientNumber >= 4:
                         self.clientNumber = 0
                     self.currPlayer = self.playerList[self.clientNumber]
-                    # question = ''
-                    # answer = ''
-                    # hasPulled = False
+                    question = ''
+                    answer = ''
+                    hasPulled = False
                     self.currState = 0
                     
                 #self.slider.listen(event)


### PR DESCRIPTION
Save/Restore has been patched to work with the intermediary screen/player order updates. 

Save/Restore now works with saving/restoring categories, colors, player info, player scores, player positions, player order, and current player.

Bug Fix: The question from the previous round doesn't get cleared if the timer times out
https://trivialcompute.atlassian.net/jira/software/projects/KAN/issues/KAN-135?jql=project%20%3D%20%22KAN%22%20ORDER%20BY%20created%20DESC

Bug Fix: Incrementing to the next player fails when current player is the last player when the number of players is less than 4
https://trivialcompute.atlassian.net/jira/software/projects/KAN/issues/KAN-136?jql=project%20%3D%20%22KAN%22%20ORDER%20BY%20created%20DESC